### PR TITLE
Add `MustGetGlobal()` for more convenient global class usage

### DIFF
--- a/global.go
+++ b/global.go
@@ -2,9 +2,41 @@
 
 package safejs
 
-import "syscall/js"
+import (
+	"fmt"
+	"syscall/js"
+)
 
 // Global returns the JavaScript global object, usually "window" or "global".
 func Global() Value {
 	return Safe(js.Global())
+}
+
+// MustGetGlobal fetches the given global, then verifies it is truthy. Panics on error or falsy values.
+// This is intended for simple global variable initialization, like preparing classes for later instantiation.
+//
+// For example:
+//
+//	var jsUint8Array = safejs.MustGetGlobal("Uint8Array")
+func MustGetGlobal(property string) Value {
+	value, err := getGlobal(property)
+	if err != nil {
+		panic(err)
+	}
+	return value
+}
+
+func getGlobal(property string) (Value, error) {
+	value, err := Global().Get(property)
+	if err != nil {
+		return Value{}, err
+	}
+	truthy, err := value.Truthy()
+	if err != nil {
+		return Value{}, err
+	}
+	if !truthy {
+		return Value{}, fmt.Errorf("global %q is not defined", property)
+	}
+	return value, nil
 }

--- a/global_test.go
+++ b/global_test.go
@@ -1,0 +1,41 @@
+//go:build js && wasm
+
+package safejs
+
+import (
+	"testing"
+
+	"github.com/hack-pad/safejs/internal/assert"
+	"github.com/hack-pad/safejs/internal/catch"
+)
+
+func TestGlobal(t *testing.T) {
+	t.Parallel()
+	global := Global()
+	self, err := global.Get("self")
+	assert.NoError(t, err)
+	assert.Equal(t, true, global.Equal(self))
+}
+
+func TestMustGetGlobal(t *testing.T) {
+	t.Parallel()
+	const className = "Uint8Array"
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		jsUint8Array, err := catch.Try(func() Value {
+			return MustGetGlobal(className)
+		})
+		assert.NoError(t, err)
+		jsUint8Array2, err := Global().Get(className)
+		assert.NoError(t, err)
+		assert.Equal(t, true, jsUint8Array.Equal(jsUint8Array2))
+	})
+
+	t.Run("undefined global", func(t *testing.T) {
+		t.Parallel()
+		_, err := catch.Try(func() Value {
+			return MustGetGlobal(className + "-foo")
+		})
+		assert.EqualError(t, err, `global "Uint8Array-foo" is not defined`)
+	})
+}


### PR DESCRIPTION

Add `MustGetGlobal()` for more convenient global class usage.

For example:
```go
package foo

import "github.com/hack-pad/safejs"

var jsUint8Array = safejs.MustGetGlobal("Uint8Array")

func Doit(b []byte) (safejs.Value, error) {
    arr, err := jsUint8Array.New(len(b))
    if err != nil {
        return safejs.Value{}, err
    }
    _, err = safejs.CopyBytesToJS(arr, b)
    return arr, err
}
```
